### PR TITLE
Do not hang in case of connection errors

### DIFF
--- a/src/smtp-pool.js
+++ b/src/smtp-pool.js
@@ -146,7 +146,12 @@ SMTPPool.prototype._processMessages = function() {
             this._rateLimit.checkpoint = Date.now();
         }
     }
-    connection.send(element.mail, element.callback);
+
+    connection.once('error', element.callback);
+    connection.send(element.mail, function (err, info) {
+        connection.removeListener('error', element.callback);
+        element.callback(err, info);
+    });
 };
 
 /**


### PR DESCRIPTION
Hey @andris9,

I've noticed that if I hit a `socketTimeout` with a message in flight, I get no callbacks, my process just hangs.

Here is a proposal to notify the caller about such unpleasant events.