### PR TITLE
Fix callback limbo due to socket connection loss

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodemailer-smtp-pool",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "SMTP transport for Nodemailer",
   "main": "src/smtp-pool.js",
   "scripts": {

--- a/src/smtp-pool.js
+++ b/src/smtp-pool.js
@@ -229,6 +229,17 @@ SMTPPool.prototype._createConnection = function() {
 };
 
 /**
+ * Continue to process message if the pool hasn't closed
+ */
+SMTPPool.prototype._continueProcessing = function() {
+    if (this._closed) {
+        this.close();
+    } else {
+        setTimeout(this._processMessages.bind(this), 100);
+    }
+};
+
+/**
  * Checks if connections have hit current rate limit and if so, queues the availability callback
  *
  * @param {Function} callback Callback function to run once rate limiter has been cleared

--- a/src/smtp-pool.js
+++ b/src/smtp-pool.js
@@ -91,7 +91,7 @@ SMTPPool.prototype.close = function() {
 
     // remove all available connections
     for (var i = this._connections.length - 1; i >= 0; i--) {
-        if (this._connections[i].available) {
+        if (this._connections[i] && this._connections[i].available) {
             connection = this._connections[i];
             connection.close();
 
@@ -99,8 +99,6 @@ SMTPPool.prototype.close = function() {
                 type: 'close',
                 message: 'Connection #' + connection.id + ' removed'
             });
-
-            this._connections.splice(i, 1);
         }
     }
 

--- a/src/smtp-pool.js
+++ b/src/smtp-pool.js
@@ -339,8 +339,8 @@ PoolResource.prototype.connect = function(callback) {
         return callback(err);
     }.bind(this));
 
-    this.connection.once('close', function() {
-        this.emit('error', new Error('Connection was closed'));
+    this.connection.once('end', function() {
+        this.close();
         if (returned) {
             return;
         }

--- a/src/smtp-pool.js
+++ b/src/smtp-pool.js
@@ -240,6 +240,20 @@ SMTPPool.prototype._continueProcessing = function() {
 };
 
 /**
+ * Remove resource from pool
+ *
+ * @param {Object} connection The PoolResource to remove
+ */
+SMTPPool.prototype._removeConnection = function(connection) {
+    for (var i = 0, len = this._connections.length; i < len; i++) {
+        if (this._connections[i] === connection) {
+            this._connections.splice(i, 1);
+            break;
+        }
+    }
+};
+
+/**
  * Checks if connections have hit current rate limit and if so, queues the availability callback
  *
  * @param {Function} callback Callback function to run once rate limiter has been cleared

--- a/src/smtp-pool.js
+++ b/src/smtp-pool.js
@@ -209,18 +209,21 @@ SMTPPool.prototype._createConnection = function() {
         }
 
         // remove the erroneus connection from connections list
-        for (var i = 0, len = this._connections.length; i < len; i++) {
-            if (this._connections[i] === connection) {
-                this._connections.splice(i, 1);
-                break;
-            }
+        this._removeConnection(connection);
+
+        this._continueProcessing();
+    }.bind(this));
+
+    connection.once('close', function() {
+        if (this.options.debug) {
+            this.emit('log', {
+                type: 'close',
+                message: 'Connection #' + connection.id + ' was closed'
+            });
         }
 
-        if (this._closed) {
-            this.close();
-        } else {
-            setTimeout(this._processMessages.bind(this), 100);
-        }
+        this._removeConnection(connection);
+        this._continueProcessing();
     }.bind(this));
 
     this._connections.push(connection);

--- a/src/smtp-pool.js
+++ b/src/smtp-pool.js
@@ -428,7 +428,9 @@ PoolResource.prototype.send = function(mail, callback) {
  * Closes the connection
  */
 PoolResource.prototype.close = function() {
+    this._connected = false;
     if (this.connection) {
         this.connection.close();
     }
+    this.emit('close');
 };


### PR DESCRIPTION
Connections would listen for a 'close' event, which was never emitted from the SMTPConnection. If the socket was closed, e.g. by the remote (before `socketTimeout`), the callback would end in limbo.